### PR TITLE
fix issue: horizontal scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,6 @@
         text-transform: uppercase;
         top: 8px;
         position: absolute;
-        left: 255px;
         padding: 6px;
         border-radius: 3px;
       }
@@ -239,6 +238,17 @@
       @keyframes fadeInUp {
         from { opacity: 0; transform: translateY(16px); }
         to   { opacity: 1; transform: translateY(0px);  }
+      }
+      @media only screen and (max-width: 450px) {
+        h1 {
+          font-size: 3em;
+        }
+        sub {
+          font-size: 8px;
+        }
+        h2 {
+          font-weight: 300;
+        }
       }
     </style>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-X1138PZ41N"></script>

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
       * {
         max-width: 100%;
         max-height: 100%;
+        box-sizing: border-box;
       }
       p {
         padding: 0;


### PR DESCRIPTION
with a width of 726px and smaller the website creates a horizontal scroll because of the border in the video element, the box-sizing property is needed to fix increasing the width because of the border.
### to understand
what happened is: the video is 720px wide, when the screen becomes less than 720px the video will have a max-width of 100% + ( 4px border * 2 sides ) > 100% of the browser width so it causes the horizontal scroll
to fix increasing the with we change the box-sizing value to border-box.
the title may cause the same problem because it is too big on small devices and the sub text has a bad positioning